### PR TITLE
[TASK] Use separate composer-root folder

### DIFF
--- a/.build/composer.json
+++ b/.build/composer.json
@@ -1,0 +1,43 @@
+{
+	"name": "friendsoftypo3/theme-portfolio-root",
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../",
+			"options": {
+				"symlink": true
+			}
+		}
+	],
+	"license": "GPL-2.0-or-later",
+	"authors": [
+		{
+			"name": "The TYPO3 Community",
+			"role": "Contributor",
+			"homepage": "https://typo3.org/community/"
+		}
+	],
+	"require": {
+		"friendsoftypo3/theme-portfolio": "dev-main",
+		"typo3/cms-core": "^13.2 || 13.*.*@dev",
+		"typo3/cms-form": "^13.2 || 13.*.*@dev",
+		"typo3/cms-frontend": "^13.2 || 13.*.*@dev"
+	},
+	"require-dev": {
+		"typo3/cms-belog": "^13.2 || 13.*.*@dev",
+		"typo3/cms-info": "^13.2 || 13.*.*@dev",
+		"typo3/cms-install": "^13.2 || 13.*.*@dev",
+		"typo3/cms-lowlevel": "^13.2 || 13.*.*@dev",
+		"typo3/cms-tstemplate": "^13.2 || 13.*.*@dev"
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"config": {
+		"allow-plugins": {
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
+		},
+		"lock": false,
+		"sort-packages": true
+	}
+}

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -13,6 +13,7 @@ use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
 corepack_enable: false
+composer_root: .build
 
 # Key features of DDEV's config.yaml:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /*.idea
 /.build/*
+!/.build/composer.json
 /.cache
 /.fleet
 /composer.lock

--- a/composer.json
+++ b/composer.json
@@ -17,35 +17,17 @@
 		"typo3/cms-form": "^13.2 || 13.*.*@dev",
 		"typo3/cms-frontend": "^13.2 || 13.*.*@dev"
 	},
-	"require-dev": {
-		"roave/security-advisories": "dev-master",
-		"typo3/cms-belog": "^13.2 || 13.*.*@dev",
-		"typo3/cms-info": "^13.2 || 13.*.*@dev",
-		"typo3/cms-install": "^13.2 || 13.*.*@dev",
-		"typo3/cms-lowlevel": "^13.2 || 13.*.*@dev",
-		"typo3/cms-tstemplate": "^13.2 || 13.*.*@dev"
-	},
-	"minimum-stability": "dev",
-	"prefer-stable": true,
 	"autoload": {
 		"psr-4": {
 			"FriendsOfTYPO3\\ThemePortfolio\\": "Classes"
 		}
 	},
 	"config": {
-		"allow-plugins": {
-			"typo3/class-alias-loader": true,
-			"typo3/cms-composer-installers": true
-		},
-		"bin-dir": ".build/bin",
-		"lock": false,
-		"sort-packages": true,
-		"vendor-dir": ".build/vendor"
+		"sort-packages": true
 	},
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "theme_portfolio",
-			"web-dir": ".build/public"
+			"extension-key": "theme_portfolio"
 		}
 	}
 }


### PR DESCRIPTION
Instead of misusing the package as a composer-root package, we now use .build/ as composer-root, which allows to install the theme extension as a regular composer-package, avoids config/ and var/ folder in the project root.

This also means we do not run into issues like
https://forge.typo3.org/issues/104345
(which will only be fixed as of 13.3)